### PR TITLE
"## Add nvm and pnpm configurations to .bash_profile"

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -202,7 +202,16 @@ case ":$PATH:" in
 esac
 # pnpm end
 
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
 # adding some testing
+=======
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
 
 # CodeWhisperer post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash" ]] && builtin source "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash"

--- a/.bash_profile
+++ b/.bash_profile
@@ -202,6 +202,7 @@ case ":$PATH:" in
 esac
 # pnpm end
 
+# adding some testing
 
 # CodeWhisperer post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash" ]] && builtin source "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash"

--- a/.bash_profile
+++ b/.bash_profile
@@ -189,5 +189,19 @@ tf() {
 # This is used for git auto-commit
 randwd() { sed -n $(jot -r 1 1 $(wc -l < /usr/share/dict/web2))p /usr/share/dict/web2 |tr '[:upper:]' '[:lower:]'; }
 
+# nvm (for aicommits)
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# pnpm (for aicommits)
+export PNPM_HOME="/Users/kristoffer.egefelt/Library/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end
+
+
 # CodeWhisperer post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash" ]] && builtin source "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash"

--- a/.bash_profile
+++ b/.bash_profile
@@ -202,16 +202,5 @@ case ":$PATH:" in
 esac
 # pnpm end
 
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-# adding some testing
-=======
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
-
 # CodeWhisperer post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash" ]] && builtin source "${HOME}/Library/Application Support/codewhisperer/shell/bash_profile.post.bash"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workstation setup
 This is for remembering how to set up my environment
-hhhhhhh
+
 ## Brew
 `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 

--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ Install github copilot for cli
 Install aicommits from Kristoffer/aicommit
 ---
 testing 123
+testing 123

--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ Install github copilot for cli
 
 Install aicommits from Kristoffer/aicommit
 ---
-
+testing 123

--- a/README.md
+++ b/README.md
@@ -126,3 +126,7 @@ Now, ```:LspInfo``` should show show both terraformls and tflint
 Install github copilot for cli
 ```gh extensions install github/gh-copilot```
 
+
+Install aicommits from Kristoffer/aicommit
+---
+


### PR DESCRIPTION
## Add nvm and pnpm configurations to .bash_profile

This pull request adds configurations for nvm and pnpm to the `.bash_profile` file. The following changes were made:

### Changes to .bash_profile
- Added export statement for `NVM_DIR` and sourced `nvm.sh` to load nvm.
- Added export statement for `PNPM_HOME` and appended `PNPM_HOME` to the `PATH` if it's not already included.

### Changes to README.md
- Added instructions to install aicommits from the repository `Kristoffer/aicommit`.

Please review and merge this pull request.